### PR TITLE
Add metadata of last commit in the changelog

### DIFF
--- a/bin/valr
+++ b/bin/valr
@@ -4,7 +4,7 @@ require 'valr'
 
 repo_path = ARGV[0] || Dir.pwd
 
-changelog = Valr.new.changelog repo_path
+changelog = Valr.new.full_changelog repo_path
 
 puts "Changelog for #{repo_path}"
 puts ""

--- a/lib/valr.rb
+++ b/lib/valr.rb
@@ -8,6 +8,13 @@ class Valr
     to_list(first_lines(log_messages(repo_path)))
   end
 
+  # Get the full changelog including metadata.
+  # @param [String] repo_path Path of repository
+  # @return [String] changelog
+  def full_changelog(repo_path)
+    "#{last_sha1(repo_path)}\n\n#{changelog(repo_path)}"
+  end
+
   private
 
   # Array to markdown list
@@ -36,5 +43,11 @@ class Valr
     messages = walker.inject([]) { |messages, c| messages << c.message }
     walker.reset
     messages
+  end
+
+  # Get the last sha1 of a git repository
+  def last_sha1(repo_path)
+    repo = Rugged::Repository.new repo_path
+    repo.head.target_id
   end
 end

--- a/spec/valr_spec.rb
+++ b/spec/valr_spec.rb
@@ -17,4 +17,18 @@ describe Valr do
       end
     end
   end
+
+  describe '#full_changelog' do
+    context 'without any specific formating' do
+      it 'returns the sha1 of the commit as a context of the changelog' do
+        valr = Valr.new
+        expect(valr.full_changelog(repo_path).lines.first.chomp).to match /^[0-9a-f]{40}$/
+      end
+
+      it 'returns a blank line and the commits in a markdown list after the metadata' do
+        valr = Valr.new
+        expect(valr.full_changelog(repo_path).lines[1..-1].join).to eq "\n- 3rd commit\n- 2nd commit\n- first commit"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add metadata (sha1) of the last commit on top of the changelog.

It allows to clarify the changelog and know the range of commits
covered.

See #2
